### PR TITLE
Concurrent drag on multiple clients

### DIFF
--- a/main.js
+++ b/main.js
@@ -516,10 +516,10 @@ function newData(json) {
   //  itemsHaveBeenDragged = false;
   //}
   var resendLater = false;
-  // do not accept movement of selected items and resend
-  // position of those
+  // do not accept movement of selected items while dragging
   if(selectedItemIDs !== [] && dragging == "items")
   {
+	  console.log("receiveing and dragging");
 	  resendLater = true;
 	  newItems.forEach(function (newItem)
 	  {
@@ -531,8 +531,6 @@ function newData(json) {
   items = newItems;
   items.forEach(ensureItemImage);
   sortItems();
-  if(resendLater)
-  {sendSyncData();}
   repaint();
 }
 

--- a/main.js
+++ b/main.js
@@ -196,7 +196,6 @@ function onMouseDown(e) {
         if (!isSelected(item)) {
           deselectAll();
           setSelected(item, true);
-		  console.log("selected ids: " + selectedItemIDs);
         }
       }
     }
@@ -218,7 +217,6 @@ function onMouseMove(e) {
     var dy = pos.y - lastDragPos.y;
     if (dragging == "items") {
       var selected = selectedItems();
-	  console.log("moved items: " + selected);
       selected.forEach(moveItem(dx, dy));
       if (selected.length > 0) {
         itemsHaveBeenDragged = true;
@@ -360,12 +358,17 @@ function isIdFree(id){
 	return free;
 }
 
-// add item to items array (and also return it)
-function addItem(imgurl, center, scale) {
+function newID(){
 	var id = Math.floor(Math.random()*1000000);
 	while(!isIdFree(id)){
-		id ++;;
-	}
+	id ++;}
+	
+	return id;
+}
+
+// add item to items array (and also return it)
+function addItem(imgurl, center, scale) {
+	var id = newID();
 	
   var item =
     { 
@@ -519,7 +522,6 @@ function newData(json) {
   // do not accept movement of selected items while dragging
   if(selectedItemIDs !== [] && dragging == "items")
   {
-	  console.log("receiveing and dragging");
 	  resendLater = true;
 	  newItems.forEach(function (newItem)
 	  {
@@ -528,6 +530,14 @@ function newData(json) {
 		  }
 	  })
   }
+  
+  newItems.forEach(i => { 
+  if(i.id === undefined){
+	  i.id = newID();
+  }
+	  
+	 });
+  
   items = newItems;
   items.forEach(ensureItemImage);
   sortItems();

--- a/main.js
+++ b/main.js
@@ -518,7 +518,7 @@ function newData(json) {
   var resendLater = false;
   // do not accept movement of selected items and resend
   // position of those
-  if(selectedItemIDs !== [])
+  if(selectedItemIDs !== [] && dragging == "items")
   {
 	  resendLater = true;
 	  newItems.forEach(function (newItem)


### PR DESCRIPTION
- Objects now have an additional random generated global ID
- item selection is now implemented via a set of IDs per client
=> selection can be maintained across synchronisation, no need to reset on data receive

conflicts on competing drags on same objects are solved:
- postion updates from other clients on dragged objects on this client are ignored
=> client who releases an object last determines its position
